### PR TITLE
Add fix for local that does not understand pointed numbers

### DIFF
--- a/iuvolt
+++ b/iuvolt
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export LC_NUMERIC="en_US.UTF-8"
+
 function round {
   val=$(printf %0.f\\n $1) 
   echo ${val}


### PR DESCRIPTION
Some local fail when trying to printf pointed number (In french, bash understand 2,3 but not 2.3 for example).