### PR TITLE
Make the service require systemd-modules-load.target

### DIFF
--- a/iuvolt.service
+++ b/iuvolt.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Undervolt cpu
 After=sleep.target suspend.target hibernate.target
+Requires=systemd-modules-load.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
because the msr module needs to be loaded before the service can start